### PR TITLE
the sfc agent handle create sf, throw exception

### DIFF
--- a/sfc-py/sfc/sfc_agent.py
+++ b/sfc-py/sfc/sfc_agent.py
@@ -289,7 +289,7 @@ def create_sf(sfname):
     for data_plane_locator in data_plane_locator_list:
         if ("ip" in data_plane_locator) and ("port" in data_plane_locator):
             sf_port = data_plane_locator['port']
-            _, sf_type = (local_sf_topo[sfname]['type']).split(':')
+            _, _, sf_type = (local_sf_topo[sfname]['type']).split(':')
             sf_ip = data_plane_locator['ip']
             # TODO: We need more checks to make sure IP in locator actually
             # corresponds to one of the existing interfaces in the system


### PR DESCRIPTION
when create a sf，the sfc agent throw exception like this:
ERROR:**main**:Exception on /config/service-function:service-functions/service-function/SF1 [PUT]
Traceback (most recent call last):
  File "/usr/local/lib/python3.4/dist-packages/flask/app.py", line 1817, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/local/lib/python3.4/dist-packages/flask/app.py", line 1477, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/local/lib/python3.4/dist-packages/flask/app.py", line 1381, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/local/lib/python3.4/dist-packages/flask/_compat.py", line 33, in reraise
    raise value
  File "/usr/local/lib/python3.4/dist-packages/flask/app.py", line 1475, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/local/lib/python3.4/dist-packages/flask/app.py", line 1461, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "sfc/sfc_agent.py", line 294, in create_sf
    _, sf_type = (local_sf_topo[sfname]['type']).split(':')
ValueError: too many values to unpack (expected 2)

but the local_sf_topo[sfname]['type'] is  {'type': 'service-function-type:service-function-type:firewall'}
